### PR TITLE
Fixed issue with chunks of iso tiles not lining up properly.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,8 +23,8 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let mut tile_storage = TileStorage::empty(tilemap_size);
 
     // Spawn the elements of the tilemap.
-    for x in 0..32u32 {
-        for y in 0..32u32 {
+    for x in 0..tilemap_size.x {
+        for y in 0..tilemap_size.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
                 .spawn()

--- a/examples/iso_staggered.rs
+++ b/examples/iso_staggered.rs
@@ -7,7 +7,7 @@ mod helpers;
 // Side length of a colored quadrant (in "number of tiles").
 // Note: the chunk size is currently hardcoded to 64. Therefore, it is good to choose a size that is above 32 for this
 // example, as it makes sure chunking-related interactions work.
-const QUADRANT_SIDE_LENGTH: u32 = 80;
+const QUADRANT_SIDE_LENGTH: u32 = 32;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(Camera2dBundle::default());
@@ -16,13 +16,9 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // In total, there will be `(QUADRANT_SIDE_LENGTH * 2) * (QUADRANT_SIDE_LENGTH * 2)` tiles.
     let total_size = TilemapSize {
-        x: QUADRANT_SIDE_LENGTH,
-        y: QUADRANT_SIDE_LENGTH,
+        x: QUADRANT_SIDE_LENGTH * 2,
+        y: QUADRANT_SIDE_LENGTH * 2,
     };
-    // let total_size = TilemapSize {
-    //     x: QUADRANT_SIDE_LENGTH * 2,
-    //     y: QUADRANT_SIDE_LENGTH * 2,
-    // };
     let quadrant_size = TilemapSize {
         x: QUADRANT_SIDE_LENGTH,
         y: QUADRANT_SIDE_LENGTH,
@@ -40,41 +36,41 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         &mut tile_storage,
     );
 
-    // bevy_ecs_tilemap::helpers::fill_tilemap_rect(
-    //     TileTexture(1),
-    //     TilePos {
-    //         x: QUADRANT_SIDE_LENGTH,
-    //         y: 0,
-    //     },
-    //     quadrant_size,
-    //     tilemap_id,
-    //     &mut commands,
-    //     &mut tile_storage,
-    // );
-    //
-    // bevy_ecs_tilemap::helpers::fill_tilemap_rect(
-    //     TileTexture(2),
-    //     TilePos {
-    //         x: 0,
-    //         y: QUADRANT_SIDE_LENGTH,
-    //     },
-    //     quadrant_size,
-    //     tilemap_id,
-    //     &mut commands,
-    //     &mut tile_storage,
-    // );
-    //
-    // bevy_ecs_tilemap::helpers::fill_tilemap_rect(
-    //     TileTexture(3),
-    //     TilePos {
-    //         x: QUADRANT_SIDE_LENGTH,
-    //         y: QUADRANT_SIDE_LENGTH,
-    //     },
-    //     quadrant_size,
-    //     tilemap_id,
-    //     &mut commands,
-    //     &mut tile_storage,
-    // );
+    bevy_ecs_tilemap::helpers::fill_tilemap_rect(
+        TileTexture(1),
+        TilePos {
+            x: QUADRANT_SIDE_LENGTH,
+            y: 0,
+        },
+        quadrant_size,
+        tilemap_id,
+        &mut commands,
+        &mut tile_storage,
+    );
+
+    bevy_ecs_tilemap::helpers::fill_tilemap_rect(
+        TileTexture(2),
+        TilePos {
+            x: 0,
+            y: QUADRANT_SIDE_LENGTH,
+        },
+        quadrant_size,
+        tilemap_id,
+        &mut commands,
+        &mut tile_storage,
+    );
+
+    bevy_ecs_tilemap::helpers::fill_tilemap_rect(
+        TileTexture(3),
+        TilePos {
+            x: QUADRANT_SIDE_LENGTH,
+            y: QUADRANT_SIDE_LENGTH,
+        },
+        quadrant_size,
+        tilemap_id,
+        &mut commands,
+        &mut tile_storage,
+    );
 
     let tile_size = TilemapTileSize { x: 64.0, y: 32.0 };
     let grid_size = tile_size.into();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -187,17 +187,23 @@ pub fn get_centered_transform_2d(
 ///
 /// `grid_width` and `grid_height` are the dimensions of the grid in pixels.
 pub fn project_iso_diamond(x: f32, y: f32, grid_width: f32, grid_height: f32) -> Vec2 {
-    let new_x = (x - y) * grid_width / 2.0;
-    let new_y = (x + y) * grid_height / 2.0;
-    Vec2::new(new_x, -new_y)
+    let dx = grid_width / 2.0;
+    let dy = grid_height / 2.0;
+
+    let new_x = (x + y) * dx;
+    let new_y = (-x + y) * dy;
+    Vec2::new(new_x, new_y)
 }
 
 /// Projects a 2D screen space point into isometric staggered space.
 ///
 /// `grid_width` and `grid_height` are the dimensions of the grid in pixels.
 pub fn project_iso_staggered(x: f32, y: f32, grid_width: f32, grid_height: f32) -> Vec2 {
-    let new_x = x * grid_width;
-    let new_y = y * grid_height;
+    let dx = grid_width / 2.0;
+    let dy = grid_height / 2.0;
+
+    let new_x = x * grid_width + y * dx;
+    let new_y = y * dy;
     Vec2::new(new_x, new_y)
 }
 

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -90,9 +90,10 @@ pub(crate) fn prepare(
             tile.tilemap_id.0.id(),
         );
 
+        let relative_tile_pos = map_tile_to_chunk_tile(&tile.position, &chunk_pos).into();
         let chunk = chunk_storage.get_or_add(
             tile.entity,
-            map_tile_to_chunk_tile(&tile.position, &chunk_pos).into(),
+            relative_tile_pos,
             &chunk_data,
             CHUNK_SIZE_2D,
             *mesh_type,
@@ -106,7 +107,7 @@ pub(crate) fn prepare(
             visibility,
         );
         chunk.set(
-            &map_tile_to_chunk_tile(&tile.position, &chunk_pos).into(),
+            &relative_tile_pos.into(),
             Some(PackedTileData {
                 position: map_tile_to_chunk_tile(&tile.position, &chunk_pos)
                     .as_vec2()

--- a/src/render/shaders/staggered_iso.wgsl
+++ b/src/render/shaders/staggered_iso.wgsl
@@ -2,12 +2,12 @@ struct Output {
     world_position: vec4<f32>,
 };
 
-fn project_iso(pos: vec2<f32>, tile_width: f32, tile_height: f32) -> vec2<f32> {
-    var dx = tile_width / 2.0;
-    var dy = tile_height / 2.0;
+fn project_iso(pos: vec2<f32>, grid_width: f32, grid_height: f32) -> vec2<f32> {
+    var dx = grid_width / 2.0;
+    var dy = grid_height / 2.0;
 
     // ux/uy is the effect of moving one tile (ux: in the x direction, uy: in the y direction) on our position
-    var ux = vec2<f32>(tile_width, 0.0);
+    var ux = vec2<f32>(grid_width, 0.0);
     var uy = vec2<f32>(dx, dy);
 
     return pos.x * ux + pos.y * uy;
@@ -17,8 +17,9 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
     var position = vertex_position.xy;
 
-    var bot_left = project_iso(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var tile_z = project_iso(tilemap_data.chunk_pos + vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let vertex_position = tilemap_data.chunk_pos + vertex_position.xy;
+    var bot_left = project_iso(vertex_position, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    var tile_z = project_iso(vertex_position, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
     var top_right = vec2<f32>(bot_left.x + tilemap_data.tile_size.x, bot_left.y + tilemap_data.tile_size.y);
 
     var positions = array<vec2<f32>, 4>(


### PR DESCRIPTION
The error was due to there being a difference between the definitions for `project_iso` provided in the shader files and those provided in the `helpers.rs` file. This is now fixed.